### PR TITLE
Support Grafana-managed alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ Each instance in the `instances` array supports:
 | `url`        | `string`                 | Yes          | The URL of the Prometheus instance                                          |
 | `headers`    | `Record<string, string>` | No           | Custom headers to include in requests (e.g., `{"X-Scope-OrgId": "team-a"}`) |
 
+### Grafana-Managed Alerts
+
+Alerts managed and evaluated by Grafana itself (rather than proxied from a Prometheus/Mimir data source) can also be
+displayed, since Grafana exposes a Prometheus-compatible endpoint for its own alert rules at
+`<grafana-url>/api/prometheus/grafana/api/v1/alerts`. Point an instance's `url` at that base path and pass a Grafana
+service account token in `headers`:
+
+```javascript
+{
+  url: "https://grafana.mydomain.com/api/prometheus/grafana",
+  headers: {
+    Authorization: "Bearer <grafana-service-account-token>"
+  }
+}
+```
+
+Grafana returns every configured rule on every poll (not just actively firing/pending ones), with a wider set of
+states than plain Prometheus, e.g. `Normal`, `Alerting`, `Pending`, optionally suffixed with a health flag such as
+`Normal (NoData)` or `Alerting (Error)`. This module normalizes those states and only displays rules that are
+actively `Alerting` (shown as firing) or `Pending`; rules in the `Normal` state are filtered out, matching how a
+native Prometheus `/api/v1/alerts` endpoint behaves.
+
 ## Config Examples
 
 ### Minimal Configuration

--- a/src/backend/PrometheusService.test.ts
+++ b/src/backend/PrometheusService.test.ts
@@ -1,4 +1,4 @@
-import { Response } from "node-fetch";
+import fetch, { Response } from "node-fetch";
 import { LogWrapper } from "../utilities/LogWrapper";
 import { PrometheusService, normalizeAlertState } from "./PrometheusService";
 import { AlertState } from "../types/Display";
@@ -16,6 +16,14 @@ jest.mock("../utilities/LogWrapper", () => {
     })
   };
 });
+
+jest.mock("node-fetch", () => ({
+  __esModule: true,
+  ...jest.requireActual("node-fetch"),
+  default: jest.fn()
+}));
+
+const mockedFetch = fetch as unknown as jest.Mock;
 
 describe("Functions in prometheus-service", function () {
   describe("checkFetchStatus", function () {
@@ -53,6 +61,58 @@ describe("Functions in prometheus-service", function () {
 
     it.each(["Normal", "Normal (NoData)", "inactive", "Normal (Error)"])(`filters out non-alerting state %s`, function (rawState) {
       expect(normalizeAlertState(rawState)).toBeUndefined();
+    });
+  });
+
+  describe("getPrometheusAlerts", function () {
+    afterEach(function () {
+      mockedFetch.mockReset();
+    });
+
+    it(`filters out non-alerting states and maps the rest`, async function () {
+      mockedFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              alerts: [
+                { labels: { alertname: "A" }, annotations: {}, state: "firing", activeAt: "2026-01-01T00:00:00Z", value: 1 },
+                { labels: { alertname: "B" }, annotations: {}, state: "Normal (NoData)", activeAt: "2026-01-01T00:00:00Z", value: 0 },
+                { labels: { alertname: "C" }, annotations: {}, state: "Pending", activeAt: "2026-01-01T00:00:00Z", value: 0 }
+              ]
+            }
+          }),
+          { status: 200 }
+        )
+      );
+
+      const service = new PrometheusService(
+        {
+          instances: [{ url: "http://localhost:8080" }],
+          updateInterval: 1000
+        },
+        new LogWrapper("TEST", undefined)
+      );
+
+      const summary = await service.getPrometheusAlerts();
+
+      expect(summary?.alerts.map((alert) => alert.labels.alertname)).toEqual(["A", "C"]);
+      expect(summary?.alerts.map((alert) => alert.state)).toEqual([AlertState.FIRING, AlertState.PENDING]);
+    });
+
+    it(`returns an empty alert list when the request fails`, async function () {
+      mockedFetch.mockResolvedValueOnce(new Response("", { status: 500, statusText: "Internal Server Error" }));
+
+      const service = new PrometheusService(
+        {
+          instances: [{ url: "http://localhost:8080" }],
+          updateInterval: 1000
+        },
+        new LogWrapper("TEST", undefined)
+      );
+
+      const summary = await service.getPrometheusAlerts();
+
+      expect(summary?.alerts).toHaveLength(0);
     });
   });
 });

--- a/src/backend/PrometheusService.test.ts
+++ b/src/backend/PrometheusService.test.ts
@@ -1,6 +1,7 @@
 import { Response } from "node-fetch";
 import { LogWrapper } from "../utilities/LogWrapper";
-import { PrometheusService } from "./PrometheusService";
+import { PrometheusService, normalizeAlertState } from "./PrometheusService";
+import { AlertState } from "../types/Display";
 
 jest.mock("../utilities/LogWrapper", () => {
   return {
@@ -35,6 +36,23 @@ describe("Functions in prometheus-service", function () {
       );
 
       expect(service.checkFetchStatus(testResponse)).toBe(testResponse);
+    });
+  });
+
+  describe("normalizeAlertState", function () {
+    it.each([
+      ["firing", AlertState.FIRING],
+      ["pending", AlertState.PENDING],
+      ["Alerting", AlertState.FIRING],
+      ["Pending", AlertState.PENDING],
+      ["Alerting (NoData)", AlertState.FIRING],
+      ["Pending (Error)", AlertState.PENDING]
+    ])(`maps raw state %s to %s`, function (rawState, expected) {
+      expect(normalizeAlertState(rawState)).toBe(expected);
+    });
+
+    it.each(["Normal", "Normal (NoData)", "inactive", "Normal (Error)"])(`filters out non-alerting state %s`, function (rawState) {
+      expect(normalizeAlertState(rawState)).toBeUndefined();
     });
   });
 });

--- a/src/backend/PrometheusService.ts
+++ b/src/backend/PrometheusService.ts
@@ -5,6 +5,21 @@ import { AlertResponse, PrometheusAlert } from "../types/Prometheus";
 import * as Display from "../types/Display";
 import { LogWrapper } from "../utilities/LogWrapper";
 
+// Grafana's compatible endpoint returns every rule (e.g. "Normal (NoData)", "Alerting"); undefined means "not actively pending/firing", so callers filter it out.
+export const normalizeAlertState = (rawState: string): Display.AlertState | undefined => {
+  const baseState = rawState.split(" ")[0].toLowerCase();
+
+  switch (baseState) {
+    case "firing":
+    case "alerting":
+      return Display.AlertState.FIRING;
+    case "pending":
+      return Display.AlertState.PENDING;
+    default:
+      return undefined;
+  }
+};
+
 export class PrometheusService {
   pending: boolean = false;
   dataConfig: DataConfig;
@@ -57,11 +72,16 @@ export class PrometheusService {
       const alerts: Display.Alert[] = [];
 
       responseData.data.alerts.forEach((alert: PrometheusAlert) => {
+        const state = normalizeAlertState(alert.state);
+        if (state === undefined) {
+          return;
+        }
+
         const activeAt: Date = new Date(Date.parse(alert.activeAt));
         alerts.push({
           labels: alert.labels,
           annotations: alert.annotations,
-          state: alert.state as Display.AlertState,
+          state,
           value: alert.value,
           age: formatDistanceToNow(activeAt, {}),
           activeAt: activeAt

--- a/src/node_helper.ts
+++ b/src/node_helper.ts
@@ -4,7 +4,7 @@ import { Summary } from "./types/Display";
 import { LogWrapper } from "./utilities/LogWrapper";
 import { PrometheusService } from "./backend/PrometheusService";
 import * as Log from "logger";
-import * as NodeHelper from "node_helper";
+import NodeHelper from "node_helper";
 
 const logger = new LogWrapper("MMM-PrometheusAlerts", Log);
 


### PR DESCRIPTION
Grafana's Prometheus-compatible alerts endpoint returns every rule (not just active ones) using its own state vocabulary (Normal, Alerting, Pending, optionally suffixed with a health flag like "(NoData)"). Add normalizeAlertState() to map those into the existing firing/pending states and filter out non-alerting rules, matching how a native Prometheus /api/v1/alerts endpoint behaves.

Also fixes a load-time crash (`NodeHelper__namespace.create is not a function`): node_helper.ts imported NodeHelper via a namespace import, which Rollup's UMD interop only copies enumerable own properties for - dropping the static `create` method. Switched to a default import so Rollup passes the class through untouched.

Document Grafana-managed alert support in the README.